### PR TITLE
fixed renaming missing callback

### DIFF
--- a/app/js/ASpell.js
+++ b/app/js/ASpell.js
@@ -42,9 +42,10 @@ setInterval(function() {
       fs.rename(cacheFsPathTmp, cacheFsPath, err => {
         if (err) {
           logger.error({ err }, 'error renaming cache file')
+        } else {
+          logger.log({ len: dump.length, cacheFsPath }, 'wrote cache file')
         }
       })
-      return logger.log({ len: dump.length, cacheFsPath }, 'wrote cache file')
     }
   })
 }, 30 * OneMinute)

--- a/app/js/ASpell.js
+++ b/app/js/ASpell.js
@@ -39,7 +39,11 @@ setInterval(function() {
       logger.log({ err }, 'error writing cache file')
       return fs.unlink(cacheFsPathTmp)
     } else {
-      fs.rename(cacheFsPathTmp, cacheFsPath)
+      fs.rename(cacheFsPathTmp, cacheFsPath, err => {
+        if (err) {
+          logger.error({ err }, 'error renaming cache file')
+        }
+      })
       return logger.log({ len: dump.length, cacheFsPath }, 'wrote cache file')
     }
   })


### PR DESCRIPTION
`fs.rename` now requires a callback, after upgrading from v6 to v10:

https://github.com/nodejs/node/blob/v10.16.0/lib/fs.js#L136
https://github.com/nodejs/node/blob/v6.16.0/lib/fs.js#L115
https://github.com/nodejs/node/blob/v10.16.0/lib/internal/errors.js#L715