### PR TITLE
[ASpell] error handling of cache dump: fix an async fs function call

### DIFF
--- a/app/js/ASpell.js
+++ b/app/js/ASpell.js
@@ -39,7 +39,7 @@ const cacheDump = setInterval(function() {
   return fs.writeFile(cacheFsPathTmp, dump, function(err) {
     if (err != null) {
       logger.log(OError.tag(err, 'error writing cache file'))
-      return fs.unlink(cacheFsPathTmp)
+      fs.unlink(cacheFsPathTmp, () => {})
     } else {
       fs.rename(cacheFsPathTmp, cacheFsPath, err => {
         if (err) {


### PR DESCRIPTION
### Description
`fs.unlink` requires a callback as second parameter.

Not providing one throws a `TypeError` - which is not handled at this time.

```
TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
    at makeCallback (fs.js:136:11)
    at Object.unlink (fs.js:943:14)
    at /app/app/js/ASpell.js:40:17
    at close (fs.js:1142:11)
    at FSReqWrap.args [as oncomplete] (fs.js:140:20)
```

#### Related Issues / PRs
#28
