### PR TITLE
[app] capture uncaught exceptions

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,6 +14,12 @@ logger.initialize('spelling')
 if ((Settings.sentry != null ? Settings.sentry.dsn : undefined) != null) {
   logger.initializeErrorReporting(Settings.sentry.dsn)
 }
+if (Settings.catchErrors) {
+  process.removeAllListeners('uncaughtException')
+  process.on('uncaughtException', function(err) {
+    logger.error({ err }, 'uncaughtException')
+  })
+}
 metrics.memory.monitor(logger)
 
 const SpellingAPIController = require('./app/js/SpellingAPIController')


### PR DESCRIPTION
### Description
Unhandled errors should not crash the app.
Instead just log them (and generate a fancy report in sentry).

#### Related Issues / PRs
Examples for unhandled exceptions: #37 #28
