### PR TITLE
[misc] fix install_deps

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -12,4 +12,6 @@ echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.list.d
 apt-get update
 apt-get install -y aspell aspell-en aspell-af aspell-am aspell-ar aspell-ar-large aspell-bg aspell-bn aspell-br aspell-ca aspell-cs aspell-cy aspell-da aspell-de aspell-de-alt aspell-el aspell-eo aspell-es aspell-et aspell-eu-es aspell-fa aspell-fo aspell-fr aspell-ga aspell-gl-minimos aspell-gu aspell-he aspell-hi aspell-hr aspell-hsb aspell-hu aspell-hy aspell-id aspell-is aspell-it aspell-kk aspell-kn aspell-ku aspell-lt aspell-lv aspell-ml aspell-mr aspell-nl aspell-nr aspell-ns  aspell-pa aspell-pl aspell-pt aspell-pt-br aspell-ro aspell-ru aspell-sk aspell-sl aspell-ss aspell-st aspell-sv aspell-tl aspell-tn aspell-ts aspell-uk aspell-uz aspell-xh aspell-zu
 
-apt-get install aspell-or=0.03-1-6 aspell-te=0.01-2-6 aspell-no=2.2-4 aspell-ta=20040424-1-2.1
+printf 'Package: aspell-*\nPin: release a=unstable\nPin-Priority: 1337\n' \
+  > /etc/apt/preferences.d/aspell-from-unstable
+apt-get install aspell-or aspell-te aspell-no aspell-ta

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -3,11 +3,11 @@ echo 'APT::Default-Release "stretch";' >/etc/apt/apt.conf.d/default-release
 # The following aspell packages exist in Ubuntu but not Debian:
 # aspell-af, aspell-id, aspell-nr, aspell-ns, aspell-ss, aspell-st, aspell-tn,
 # aspell-ts, aspell-xh, aspell-zu
-echo "deb http://us.archive.ubuntu.com/ubuntu/ bionic main universe" > /etc/apt/sources.list.d/bionic.list
+echo "deb http://archive.ubuntu.com/ubuntu/ bionic main universe" > /etc/apt/sources.list.d/bionic.list
 apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
 # Need to install aspell-or, aspell-ta and aspell-te from testing (buster) as
 # broken in stable (stretch).
-echo "deb http://http.us.debian.org/debian/ unstable main" > /etc/apt/sources.list.d/unstable.list
+echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.list.d/unstable.list
 
 apt-get update
 apt-get install -y aspell aspell-en aspell-af aspell-am aspell-ar aspell-ar-large aspell-bg aspell-bn aspell-br aspell-ca aspell-cs aspell-cy aspell-da aspell-de aspell-de-alt aspell-el aspell-eo aspell-es aspell-et aspell-eu-es aspell-fa aspell-fo aspell-fr aspell-ga aspell-gl-minimos aspell-gu aspell-he aspell-hi aspell-hr aspell-hsb aspell-hu aspell-hy aspell-id aspell-is aspell-it aspell-kk aspell-kn aspell-ku aspell-lt aspell-lv aspell-ml aspell-mr aspell-nl aspell-nr aspell-ns  aspell-pa aspell-pl aspell-pt aspell-pt-br aspell-ro aspell-ru aspell-sk aspell-sl aspell-ss aspell-st aspell-sv aspell-tl aspell-tn aspell-ts aspell-uk aspell-uz aspell-xh aspell-zu


### PR DESCRIPTION
### Description

The version of `aspell-ta` was bumped again, which broke the builds. `aspell-or` and `aspell-no` were bumped as well.

This time I am proposing to use any latest version that is available.

I added a policy and pinned the release for the `aspell-*` packages to `unstable`.
The priority must be larger than the `APT::Default-Release` priority of 990.
This applies to the second batch of package installations only.

#### Screenshots

<details>

```
# in a node:10.19.0 container will all steps from install_deps.sh
#  executed -- except for the 'apt install' steps.
$ apt policy aspell-or aspell-te aspell-no aspell-ta
  aspell-or:
    Installed: (none)
    Candidate: 0.03-1-7
    Version table:
       0.03-1-7 1337
          500 http://deb.debian.org/debian unstable/main ...
       0.03-1-5 990
          990 http://deb.debian.org/debian stretch/main ...
       0.03-1-5 500
          500 http://archive.ubuntu.com/ubuntu bionic/universe ...
  aspell-te:
    Installed: (none)
    Candidate: 0.01-2-7
    Version table:
       0.01-2-7 1337
          500 http://deb.debian.org/debian unstable/main ...
       0.01-2-5 990
          990 http://deb.debian.org/debian stretch/main ...
       0.01-2-5 500
          500 http://archive.ubuntu.com/ubuntu bionic/universe ...
  aspell-no:
    Installed: (none)
    Candidate: 2.2-4
    Version table:
       2.2-4 1337
          500 http://deb.debian.org/debian unstable/main ...
       2.2-3 500
          500 http://archive.ubuntu.com/ubuntu bionic/universe ...
       2.2-2 990
          990 http://deb.debian.org/debian stretch/main ...
  aspell-ta:
    Installed: (none)
    Candidate: 20040424-1-3
    Version table:
       20040424-1-3 1337
          500 http://deb.debian.org/debian unstable/main ...
       20040424-1-1 990
          990 http://deb.debian.org/debian stretch/main ...
       20040424-1-1 500
          500 http://archive.ubuntu.com/ubuntu bionic/universe ...
```
</details>

#### Related Issues / PRs

https://github.com/overleaf/spelling/pull/55 https://github.com/overleaf/spelling/pull/54 https://github.com/overleaf/spelling/pull/16

#### Review

To speed up local builds I switched from the us mirrors to the respective mirror redirectors.