### PR TITLE
[ASpell] error handling of cache dump: fix an async fs function call

### DIFF
--- a/app/js/ASpell.js
+++ b/app/js/ASpell.js
@@ -39,7 +39,7 @@ const cacheDump = setInterval(function() {
   return fs.writeFile(cacheFsPathTmp, dump, function(err) {
     if (err != null) {
       logger.log(OError.tag(err, 'error writing cache file'))
-      return fs.unlink(cacheFsPathTmp)
+      fs.unlink(cacheFsPathTmp, () => {})
     } else {
       fs.rename(cacheFsPathTmp, cacheFsPath, err => {
         if (err) {


### PR DESCRIPTION
### Description

This PR will trigger a CI run. For details on the change see #37 

#### Related Issues / PRs

#37

#### Potential Impact

Low. Fixes a crash in the error path of the periodic cache dump.

#### Manual Testing Performed

- I've been running this since October 2019 in my infra and given that I ran into the error path once, I likely did so again in the past 9 months.

