### PR TITLE
[SpellingAPIManager] get the list of ignored misspellings from settings

### DIFF
--- a/app/js/SpellingAPIManager.js
+++ b/app/js/SpellingAPIManager.js
@@ -10,12 +10,13 @@ const ASpell = require('./ASpell')
 const LearnedWordsManager = require('./LearnedWordsManager')
 const { callbackify } = require('util')
 const OError = require('@overleaf/o-error')
+const Settings = require('settings-sharelatex')
 
 // The max number of words checked in a single request
 const REQUEST_LIMIT = 10000
 
 const SpellingAPIManager = {
-  whitelist: ['ShareLaTeX', 'sharelatex', 'LaTeX', 'http', 'https', 'www'],
+  whitelist: Settings.ignoredMisspellings,
 
   learnWord(token, request, callback) {
     if (callback == null) {

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -24,7 +24,16 @@ module.exports = {
 
   ignoredMisspellings: process.env.IGNORED_MISSPELLINGS
     ? process.env.IGNORED_MISSPELLINGS.split(',')
-    : ['ShareLaTeX', 'sharelatex', 'LaTeX', 'http', 'https', 'www'],
+    : [
+        'Overleaf',
+        'overleaf',
+        'ShareLaTeX',
+        'sharelatex',
+        'LaTeX',
+        'http',
+        'https',
+        'www'
+      ],
 
   sentry: {
     dsn: process.env.SENTRY_DSN

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -22,6 +22,10 @@ module.exports = {
 
   healthCheckUserId: '53c64d2fd68c8d000010bb5f',
 
+  ignoredMisspellings: process.env.IGNORED_MISSPELLINGS
+    ? process.env.IGNORED_MISSPELLINGS.split(',')
+    : ['ShareLaTeX', 'sharelatex', 'LaTeX', 'http', 'https', 'www'],
+
   sentry: {
     dsn: process.env.SENTRY_DSN
   }

--- a/test/unit/js/SpellingAPIManagerTests.js
+++ b/test/unit/js/SpellingAPIManagerTests.js
@@ -30,6 +30,7 @@ describe('SpellingAPIManager', function () {
     this.SpellingAPIManager = SandboxedModule.require(modulePath, {
       requires: {
         './ASpell': this.ASpell,
+        'settings-sharelatex': { ignoredMisspellings: ['ShareLaTeX'] },
         './LearnedWordsManager': this.LearnedWordsManager
       }
     })


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3454

This PR allows us to insert not-so correct words like `COVID` into the ignored misspellings w/o impacting hosted versions.

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3454

#### Potential Impact

High. The ignored misspellings array is accessed on every spell check request. There are acceptance tests to cover the code path.

#### Manual Testing Performed

- add custom env var in the dev-env

```diff
diff --git a/docker-compose.yml b/docker-compose.yml
index bfe2d3c7a..4f6e26264 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -258,0 +259,2 @@ services:
+    environment:
+      IGNORED_MISSPELLINGS: 'COVID,ShareLaTeX'
``` 
- start core + spelling: `dev-env$ bin/up core spelling`
- write `COVID` and another misspelled word -- only the other word should get marked as misspelled

#### Deployment Checklist

- [ ] merge google-ops PR https://github.com/overleaf/google-ops/pull/1296
