### PR TITLE
[misc] drop unused node-statsd package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4410,11 +4410,6 @@
         }
       }
     },
-    "node-statsd": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.1.1.tgz",
-      "integrity": "sha512-QDf6R8VXF56QVe1boek8an/Rb3rSNaxoFWb7Elpsv2m1+Noua1yy0F1FpKpK5VluF8oymWM4w764A4KsYL4pDg=="
-    },
     "nopt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "logger-sharelatex": "^2.2.0",
     "lru-cache": "^5.1.1",
     "mongodb": "^3.6.0",
-    "node-statsd": "0.1.1",
     "request": "^2.88.2",
     "settings-sharelatex": "^1.1.0",
     "underscore": "1.9.2"


### PR DESCRIPTION
### Description

The metrics module does not support statsd anymore. Drop the now unused node-statsd package.

#### Related Issues / PRs

papercut 31

#### Potential Impact

Low.

#### Manual Testing Performed

- load editor and see spelling errors
